### PR TITLE
fix: adding a wildcard subdomain to the DNS configurations

### DIFF
--- a/infra/tf/modules/digital_ocean/app/app.tf
+++ b/infra/tf/modules/digital_ocean/app/app.tf
@@ -7,6 +7,7 @@ resource "digitalocean_app" "app" {
       name = var.apex_domain
       type = "PRIMARY"
       zone = var.apex_domain
+      wildcard = true
     }
 
     service {


### PR DESCRIPTION
Currently, https://smerc.dev resolves as expected, but no subdomains resolve. 

This enables a wildcard route with digital ocean apps to set it up for us.
